### PR TITLE
bugfix/patch number reset

### DIFF
--- a/internal/controllers/increase.go
+++ b/internal/controllers/increase.go
@@ -36,6 +36,7 @@ func IncreaseVersionAlpha(version *entities.Version) *entities.Version {
 
 	version.Minor++
 	version.Phase = phases.Alpha
+	version.Patch = 0
 	version.PatchNumber = 1
 
 	return version

--- a/internal/controllers/increase_test.go
+++ b/internal/controllers/increase_test.go
@@ -9,10 +9,10 @@ import (
 func TestIncreaseVersionAlpha(t *testing.T) {
 	Convey("Given an previous version and increase to next alpha", t, func() {
 		Convey("When previous version is already and alpha", func() {
-			version, _ := entities.NewVersion("1.0.0-alpha.1")
+			version, _ := entities.NewVersion("1.0.1-alpha.1")
 			Convey("Then should increase patch count version", func() {
 				newVersion := IncreaseVersionAlpha(version)
-				So(newVersion.String(), ShouldEqual, "v1.0.0-alpha.2")
+				So(newVersion.String(), ShouldEqual, "v1.0.1-alpha.2")
 			})
 		})
 
@@ -57,7 +57,7 @@ func TestIncreaseVersionAlpha(t *testing.T) {
 		})
 
 		Convey("When previous version is an release", func() {
-			version, _ := entities.NewVersion("1.0.0")
+			version, _ := entities.NewVersion("1.0.1")
 			Convey("Then should increase patch count version", func() {
 				newVersion := IncreaseVersionAlpha(version)
 				So(newVersion.String(), ShouldEqual, "v1.1.0-alpha.1")


### PR DESCRIPTION
Fix increase version logic when increasing a release version with patch number bigger than 0 to a new alpha version.

In this case, the minor version should be increased and patch number set to 0.